### PR TITLE
Update pretty-printing code to work with current version of prettyprinter

### DIFF
--- a/src/Stg/Language/Prettyprint.hs
+++ b/src/Stg/Language/Prettyprint.hs
@@ -27,22 +27,22 @@ import qualified Text.PrettyPrint.ANSI.Leijen              as Leijen
 
 
 renderRich :: Doc StgiAnn -> Text
-renderRich = PrettyAnsi.renderStrict . alterAnnotationsS terminalStyle . layoutPretty layoutOptions
+renderRich = PrettyAnsi.renderStrict . alterAnnotationsS (Just . terminalStyle) . layoutPretty layoutOptions
   where
-    terminalStyle :: StgiAnn -> Maybe AnsiTerminal
+    terminalStyle :: StgiAnn -> AnsiStyle
     terminalStyle = \case
         StateAnn x -> case x of
-            Headline       -> Just (Color Foreground Dull Blue)
-            Address        -> Just (Color Foreground Dull Cyan)
-            AddressCore    -> Just Underlined
-            ClosureType    -> Just Bold
-            StackFrameType -> Just Bold
+            Headline       -> colorDull Blue
+            Address        -> colorDull Cyan
+            AddressCore    -> underlined
+            ClosureType    -> bold
+            StackFrameType -> bold
         AstAnn x -> case x of
-            Keyword     -> Nothing
-            Prim        -> Just (Color Foreground Dull Green)
-            Variable    -> Just (Color Foreground Dull Yellow)
-            Constructor -> Just (Color Foreground Dull Magenta)
-            Semicolon   -> Just (Color Foreground Dull White)
+            Keyword     -> colorDull White
+            Prim        -> colorDull Green
+            Variable    -> colorDull Yellow
+            Constructor -> colorDull Magenta
+            Semicolon   -> colorDull White
 
 renderPlain :: Doc ann -> Text
 renderPlain = PrettyPlain.renderStrict . layoutPretty layoutOptions

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
-resolver: lts-8.15
+resolver: lts-8.20
 packages:
     - '.'
 extra-deps:
-    - prettyprinter-1.0.1
-    - prettyprinter-ansi-terminal-1.0.1
+  - prettyprinter-1.1
+  - prettyprinter-ansi-terminal-1.1
 flags: {}
 extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ resolver: lts-8.20
 packages:
     - '.'
 extra-deps:
-  - prettyprinter-1.1
-  - prettyprinter-ansi-terminal-1.1
+    - prettyprinter-1.1
+    - prettyprinter-ansi-terminal-1.1
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
Other than the simple modifications, I had to change the `Nothing` case because I was getting `Peeked an empty style stack` from:

https://quchen.github.io/ansi-wl-pprint-docdump/prettyprinter-1.1/src/Data.Text.Prettyprint.Doc.Render.Util.StackMachine.html#unsafePeekStyle

