### PR TITLE
Extend rule6 InfoDetail with info about new bindings

### DIFF
--- a/src/Stg/Machine/Evaluate/ValidTransitions.hs
+++ b/src/Stg/Machine/Evaluate/ValidTransitions.hs
@@ -237,12 +237,13 @@ rule6_algebraicNormalMatch s@StgState
     , length ws == length vars
 
   = let locals' = addLocals (zipWith Mapping vars ws) locals
+        boundLocals = zipWith Mapping vars ws
 
     in Just (s
         { stgCode  = Eval expr locals'
         , stgStack = stack'
         , stgInfo  = Info (StateTransition Rule6_ReturnCon_Match)
-                          [Detail_ReturnCon_Match con vars] })
+                          [Detail_ReturnCon_Match con boundLocals] })
 
 rule6_algebraicNormalMatch _ = Nothing
 

--- a/src/Stg/Machine/Evaluate/ValidTransitions.hs
+++ b/src/Stg/Machine/Evaluate/ValidTransitions.hs
@@ -236,14 +236,14 @@ rule6_algebraicNormalMatch s@StgState
         lookupAlgebraicAlt alts con
     , length ws == length vars
 
-  = let locals' = addLocals (zipWith Mapping vars ws) locals
-        boundLocals = zipWith Mapping vars ws
+  = let locals' = addLocals newLocals locals
+        newLocals = zipWith Mapping vars ws
 
     in Just (s
         { stgCode  = Eval expr locals'
         , stgStack = stack'
         , stgInfo  = Info (StateTransition Rule6_ReturnCon_Match)
-                          [Detail_ReturnCon_Match con boundLocals] })
+                          [Detail_ReturnCon_Match con newLocals] })
 
 rule6_algebraicNormalMatch _ = Nothing
 

--- a/src/Stg/Machine/Types.hs
+++ b/src/Stg/Machine/Types.hs
@@ -366,7 +366,7 @@ data InfoDetail =
     | Detail_EnterNonUpdatable MemAddr [Mapping Var Value]
     | Detail_EvalLet [Var] [MemAddr]
     | Detail_EvalCase
-    | Detail_ReturnCon_Match Constr [Var]
+    | Detail_ReturnCon_Match Constr [Mapping Var Value]
     | Detail_ReturnConDefBound Var MemAddr
     | Detail_ReturnIntDefBound Var Integer
     | Detail_EnterUpdatable MemAddr
@@ -429,7 +429,12 @@ instance PrettyStgi InfoDetail where
             ["Save alternatives and local environment as a stack frame"]
 
         Detail_ReturnCon_Match con args ->
-            ["Pattern" <+> prettyStgi (AppC con (map AtomVar args)) <+> "matches, follow its branch"]
+            ["Pattern" <+> prettyStgi (AppC con (map (\(Mapping a _) -> AtomVar a) args)) <+> "matches, follow its branch"
+            , if null args
+                then mempty
+                else hang 4 (vsep
+                        [ "Extend local environment with matched pattern variables' values:"
+                        , commaSep (foldMap (\arg -> [prettyStgi arg]) args) ])]
 
         Detail_ReturnConDefBound var addr ->
             [ "Allocate closure at" <+> prettyStgi addr <+> "for the bound value"

--- a/src/Stg/Machine/Types.hs
+++ b/src/Stg/Machine/Types.hs
@@ -429,12 +429,13 @@ instance PrettyStgi InfoDetail where
             ["Save alternatives and local environment as a stack frame"]
 
         Detail_ReturnCon_Match con args ->
-            ["Pattern" <+> prettyStgi (AppC con (map (\(Mapping a _) -> AtomVar a) args)) <+> "matches, follow its branch"
-            , if null args
-                then mempty
-                else hang 4 (vsep
-                        [ "Extend local environment with matched pattern variables' values:"
-                        , commaSep (foldMap (\arg -> [prettyStgi arg]) args) ])]
+            let pat = prettyStgi (AppC con (map (\(Mapping a _) -> AtomVar a) args))
+            in ["Pattern" <+> pat <+> "matches, follow its branch"
+               , if null args
+                   then "No need to augment local environment for nullary constructor" <+> pat
+                   else hang 4 (vsep
+                           [ "Extend local environment with matched pattern variables' values:"
+                           , commaSep (foldMap (\arg -> [prettyStgi arg]) args) ])]
 
         Detail_ReturnConDefBound var addr ->
             [ "Allocate closure at" <+> prettyStgi addr <+> "for the bound value"


### PR DESCRIPTION
In rule 6 `Algebraic constructor return, standard match` we extend local environment with new bindings captured by the matched pattern. Although, the rule documentation does mention that,  we never actually inform the user about that.
<img width="650" alt="Screen Shot 2019-05-11 at 10 48 19 AM" src="https://user-images.githubusercontent.com/8581663/57573799-c9fb3f00-73e2-11e9-956c-5eda03f1efca.png">
We now reflect this change in InfoDetail as well.
<img width="649" alt="Screen Shot 2019-05-11 at 11 22 07 AM" src="https://user-images.githubusercontent.com/8581663/57573803-cff12000-73e2-11e9-84d4-ccd26c04489d.png">
